### PR TITLE
Fix resource ID references to be unique

### DIFF
--- a/terraform/modules/route53/main.tf
+++ b/terraform/modules/route53/main.tf
@@ -9,7 +9,10 @@ resource "aws_route53_zone" "default" {
 }
 
 resource "aws_route53_record" "default" {
-  for_each = { for record in var.records : record.name => record }
+  for_each = {
+    for record in var.records :
+    join("_", [aws_route53_zone.default.zone_id, record.name, record.type]) => record
+  }
 
   zone_id = aws_route53_zone.default.zone_id
   name    = each.value.name


### PR DESCRIPTION
This PR changes how resource IDs (keys) are created to make them unique across zones, names, and types.

Previously, given this configuration:
```hcl
module "domain" {
  source = "./modules/route53"

  domain = "et.dsd.io"

  records = [
    {
      name = "example.com",
      type = "TXT",
      ttl  = 300,
      records = [
        "text-record"
      ]
    },
    {
      name = "example.com",
      type = "CNAME",
      ttl  = 300,
      records = [
        "subdomain.example.com"
      ]
    }
  ]
}
```

Terraform would fail as the resource key was generated on the record name _only_, creating duplicate values, namely: `"module.domain.aws_route53_record.default["example.com"]"` for both records.

This change creates keys based on the zone ID, record name, and record type, creating distinct resource keys, in this case:
`"module.domain.aws_route53_record.default["HOSTED_ZONE_ID_example.com_TXT"]"`
`"module.domain.aws_route53_record.default["HOSTED_ZONE_ID_example.com_CNAME"]"`

This is also how Terraform itself [references IDs internally (statefile and such) for records](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record#import).