### PR TITLE
Remove hosted zone ID as a key reference in for_each

### DIFF
--- a/terraform/modules/route53/main.tf
+++ b/terraform/modules/route53/main.tf
@@ -11,7 +11,7 @@ resource "aws_route53_zone" "default" {
 resource "aws_route53_record" "default" {
   for_each = {
     for record in var.records :
-    join("_", [aws_route53_zone.default.zone_id, record.name, record.type]) => record
+    join("_", [record.name, record.type]) => record
   }
 
   zone_id = aws_route53_zone.default.zone_id


### PR DESCRIPTION
This PR splits removes the hosted zone ID as a key reference in `for_each` for the module, as there are issues with `for_each` on how Route 53 records are currently created.

As the `for_each` block for Route 53 records currently [uses the Hosted Zone ID](https://github.com/ministryofjustice/dns-iac/blob/main/terraform/modules/route53/main.tf#L14) as a key, Terraform can't calculate the value until the hosted zone is created. This results in the following error:

```sh
│   on modules/route53/main.tf line 12, in resource "aws_route53_record" "default":
│   12:   for_each = {
│   13:     for record in var.records :
│   14:     join("_", [aws_route53_zone.default.zone_id, record.name, record.type]) => record
│   15:   }
│     ├────────────────
│     │ aws_route53_zone.default.zone_id is a string, known only after apply
│     │ var.records is tuple with 15 elements
│ 
│ The "for_each" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use
│ the -target argument to first apply only the resources that the for_each depends on.
```

As Route 53 supports multiple values on multiple lines, each record `name` and `type` should satisfy the unique requirement needed for each record, as multiple values can be created using the same key.