### PR TITLE
Prepare for splitting Route53 module into two (zone, records)

### DIFF
--- a/terraform/modules/route53/zone/main.tf
+++ b/terraform/modules/route53/zone/main.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_zone" "this" {
+  name              = var.name
+  comment           = var.description
+  delegation_set_id = var.delegation_set_id
+  force_destroy     = var.force_destroy
+  tags              = var.tags
+}

--- a/terraform/modules/route53/zone/outputs.tf
+++ b/terraform/modules/route53/zone/outputs.tf
@@ -1,0 +1,11 @@
+output "zone_id" {
+  value = aws_route53_zone.this.zone_id
+}
+
+output "name_servers" {
+  value = aws_route53_zone.this.name_servers
+}
+
+output "name" {
+  value = aws_route53_zone.this.name
+}

--- a/terraform/modules/route53/zone/variables.tf
+++ b/terraform/modules/route53/zone/variables.tf
@@ -1,0 +1,21 @@
+variable "name" {
+  type = string
+}
+
+variable "description" {
+  type = string
+}
+
+variable "delegation_set_id" {
+  type = string
+}
+
+variable "force_destroy" {
+  type        = bool
+  default     = false
+  description = "Whether to force destroy this zone (and destroy all records)"
+}
+
+variable "tags" {
+  type = map(any)
+}

--- a/terraform/modules/route53/zone/versions.tf
+++ b/terraform/modules/route53/zone/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.4"
+    }
+  }
+}


### PR DESCRIPTION
This PR creates a new module that only creates Route53 hosted zones. This is because there will be a race-case between the current module where it may need to reference other hosted zones that won't be created before the records are added, so this new module will ensure the hosted zones are created before records are added.