### PR TITLE
Refactor acceleratedpossession.service.gov.uk to use new modules

### DIFF
--- a/terraform/acceleratedpossession.service.gov.uk.tf
+++ b/terraform/acceleratedpossession.service.gov.uk.tf
@@ -1,21 +1,23 @@
-module "acceleratedpossession_service_gov_uk" {
-  source = "./modules/route53"
+module "acceleratedpossession_service_gov_uk_zone" {
+  source = "./modules/route53/zone"
 
-  domain      = "acceleratedpossession.service.gov.uk"
-  description = ""
+  name = "acceleratedpossession.service.gov.uk"
+
+  tags = {
+    application            = "Accelerated Possession/AP aka Accelerated Claims aka Civil Claims"
+    business-unit          = "HMCTS"
+    component              = "None"
+    infrastructure-support = "HMCTS sustainingteamsupport@hmcts.net"
+    owner                  = "HMCTS sustainingteamsupport@hmcts.net"
+  }
+}
+
+module "acceleratedpossession_service_gov_uk_records" {
+  source = "./modules/route53/records"
+
+  zone_id = module.acceleratedpossession_service_gov_uk_zone.zone_id
 
   records = [
-    {
-      name = "acceleratedpossession.service.gov.uk."
-      type = "NS"
-      ttl  = 172800
-      records = [
-        "ns-1990.awsdns-56.co.uk.",
-        "ns-1195.awsdns-21.org.",
-        "ns-159.awsdns-19.com.",
-        "ns-713.awsdns-25.net."
-      ]
-    },
     {
       name = "_dmarc.acceleratedpossession.service.gov.uk."
       type = "TXT"
@@ -25,12 +27,4 @@ module "acceleratedpossession_service_gov_uk" {
       ]
     }
   ]
-
-  tags = {
-    application            = "Accelerated Possession/AP aka Accelerated Claims aka Civil Claims"
-    business-unit          = "HMCTS"
-    component              = "None"
-    infrastructure-support = "HMCTS sustainingteamsupport@hmcts.net"
-    owner                  = "HMCTS sustainingteamsupport@hmcts.net"
-  }
 }


### PR DESCRIPTION
This PR refactors `acceleratedpossession.service.gov.uk.tf` to use the new Route53 modules; and removes the NS records as they are automatically created by AWS (even if we recreate the hosted zone).