### PR TITLE
Add defensive domains records for probationservice.uk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/terraform"
     schedule:
       interval: "daily"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/defensive-domains"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/terraform/defensive-domains/.terraform.lock.hcl
+++ b/terraform/defensive-domains/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.17.1"
+  constraints = "~> 4.4"
+  hashes = [
+    "h1:Oso/TFSIASSroiCyJYKA4Dm7gPxKfcmoU4qXpkgSAm8=",
+    "zh:095c2ad4e42667b6e4c599f3fb7c1d0755b762983474fd3916e89867c30871a2",
+    "zh:0a987960f796289db7eac887d03dcde0311005cbf625499f4eea0a8882295aeb",
+    "zh:1fbe5f897afe3a9e5a41c2ecd1f312e79fb6745367a53f7bad11704aedb3b3e2",
+    "zh:52687f0753fa05a744bd37bb40bcba8ac5e0838cdcd227035b9ccb151635e5f9",
+    "zh:629835a96c682f4e168c12f6d3c0631409d8e6d28165a283d2fe232c4a8ba75a",
+    "zh:6fa6e6fbdc0b0377d750a7960768e22f71d8bd97d30e289b823a3923eb92fce7",
+    "zh:8dfef513861a7c779b34e2f3ea5692f5fb1fb51aa1ee9de78bc755f5652cb597",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:baf507b37a667c773f46d9779277ab9de44a5432694ef95fe9ef03a6af70435f",
+    "zh:bd006bd8f1403f71be8f490e33ea1bcbdd8135678ebe3f1c3c0ebd82615d9b33",
+    "zh:dd0a61fb654837d186376b1dbccc8a93ed1e2f176e3663daac2d5bc9190c7895",
+    "zh:f8db068265495a48476a5ea68aa7148ceb046cbfaad308ef8e12d8fd6f463126",
+  ]
+}

--- a/terraform/defensive-domains/route53.tf
+++ b/terraform/defensive-domains/route53.tf
@@ -1,0 +1,73 @@
+resource "aws_route53domains_registered_domain" "example" {
+  for_each = toset(var.domains)
+
+  domain_name   = each.value
+  transfer_lock = false
+
+  dynamic "name_server" {
+    for_each = sort(toset(data.aws_route53_zone.hosted_zone[each.value].name_servers))
+
+    content {
+      name = name_server.value
+    }
+  }
+}
+
+data "aws_route53_zone" "hosted_zone" {
+  for_each = toset(var.domains)
+
+  name         = each.value
+  private_zone = false
+}
+
+module "defensive_domain_records" {
+  for_each = toset(var.domains)
+
+  source = "../modules/route53/records"
+
+  zone_id = data.aws_route53_zone.hosted_zone[each.value].zone_id
+
+  records = [
+    {
+      name = each.value
+      type = "TXT"
+      ttl  = 300
+      records = [
+        "v=spf1 -all", # NULL SPF
+      ]
+    },
+    {
+      name = each.value
+      type = "CAA"
+      ttl  = 300
+      records = [
+        "0 iodef \"mailto:certificates@digital.justice.gov.uk\"",
+        "0 issue \";\""
+      ]
+    },
+    {
+      name = each.value
+      type = "MX"
+      ttl  = 300
+      records = [
+        "0 ."
+      ]
+    },
+    {
+      name = "_dmarc.${each.value}"
+      type = "TXT"
+      ttl  = 300
+      records = [
+        "v=DMARC1;p=reject;rua=mailto:dmarc-rua@dmarc.service.gov.uk;" # DMARC reject policy
+      ]
+    },
+    {
+      name = "*._domainkey.${each.value}"
+      type = "TXT"
+      ttl  = 300
+      records = [
+        "v=DKIM1; p=" # Wildcard DKIM key
+      ]
+    }
+  ]
+}

--- a/terraform/defensive-domains/terraform.tfvars
+++ b/terraform/defensive-domains/terraform.tfvars
@@ -1,0 +1,3 @@
+domains = [
+  "probationservice.uk"
+]

--- a/terraform/defensive-domains/variables.tf
+++ b/terraform/defensive-domains/variables.tf
@@ -1,0 +1,3 @@
+variable "domains" {
+  type = list(string)
+}

--- a/terraform/defensive-domains/versions.tf
+++ b/terraform/defensive-domains/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "s3" {
+    bucket  = "dns-terraform-state20211206173317424200000001"
+    key     = "terraform-defensive-domains.tfstate"
+    region  = "eu-west-2"
+    encrypt = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.4"
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = "eu-west-2"
+}


### PR DESCRIPTION
This PR creates a new directory to manage the Terraform for defensively registered domains, in accordance with NCSC's guidance for [protecting parked domains for the UK public sector](https://www.ncsc.gov.uk/blog-post/protecting-parked-domains) and MOJ's technical guidance for [mandatory DNS records for domains](https://technical-guidance.service.justice.gov.uk/documentation/standards/how-to-get-a-domain-name.html#mandatory-dns-records-for-domains).

Do note that `aws_route53domains_registered_domain` does not _register_ a domain, but "adopts" a domain into Terraform management.

This is to replace the previous [dns](https://github.com/ministryofjustice/dns/tree/main/defensive-domains) configuration code for defensively registered domains.