### PR TITLE
Change CNAME records for dsd.io S3 websites to Alias records

### DIFF
--- a/terraform/dsd.io.tf
+++ b/terraform/dsd.io.tf
@@ -244,11 +244,12 @@ module "dsd_io_records" {
     },
     {
       name = "can-you-get-legal-aid.dsd.io.",
-      type = "CNAME",
-      ttl  = 300,
-      records = [
-        "can-you-get-legal-aid.dsd.io.s3-website-eu-west-1.amazonaws.com"
-      ]
+      type = "A",
+      alias = {
+        zone_id                = "Z1BKCTXD74EZPE"
+        name                   = "s3-website-eu-west-1.amazonaws.com."
+        evaluate_target_health = false
+      }
     },
     {
       name = "carestandardstribunal.dsd.io.",
@@ -629,11 +630,12 @@ module "dsd_io_records" {
     },
     {
       name = "ctf.dsd.io.",
-      type = "CNAME",
-      ttl  = 300,
-      records = [
-        "ctf.dsd.io.s3-website-eu-west-1.amazonaws.com"
-      ]
+      type = "A",
+      alias = {
+        zone_id                = "Z1BKCTXD74EZPE"
+        name                   = "s3-website-eu-west-1.amazonaws.com."
+        evaluate_target_health = false
+      }
     },
     {
       name = "dacp.dsd.io.",
@@ -645,11 +647,12 @@ module "dsd_io_records" {
     },
     {
       name = "et.dashboard.dsd.io.",
-      type = "CNAME",
-      ttl  = 300,
-      records = [
-        "et.dashboard.dsd.io.s3-website-eu-west-1.amazonaws.com"
-      ]
+      type = "A",
+      alias = {
+        zone_id                = "Z1BKCTXD74EZPE"
+        name                   = "s3-website-eu-west-1.amazonaws.com."
+        evaluate_target_health = false
+      }
     },
     {
       name = "defence-request.dsd.io.",
@@ -1645,11 +1648,12 @@ module "dsd_io_records" {
     },
     {
       name = "one3one.dsd.io.",
-      type = "CNAME",
-      ttl  = 300,
-      records = [
-        "one3one.dsd.io.s3-website-eu-west-1.amazonaws.com."
-      ]
+      type = "A",
+      alias = {
+        zone_id                = "Z1BKCTXD74EZPE"
+        name                   = "s3-website-eu-west-1.amazonaws.com."
+        evaluate_target_health = false
+      }
     },
     {
       name = "openjustice.dsd.io.",
@@ -2915,11 +2919,12 @@ module "dsd_io_records" {
     },
     {
       name = "static.dsd.io.",
-      type = "CNAME",
-      ttl  = 300,
-      records = [
-        "static.dsd.io.s3-website-eu-west-1.amazonaws.com"
-      ]
+      type = "A",
+      alias = {
+        zone_id                = "Z1BKCTXD74EZPE"
+        name                   = "s3-website-eu-west-1.amazonaws.com."
+        evaluate_target_health = false
+      }
     },
     {
       name = "deployarn.active.dev.status.dsd.io.",

--- a/terraform/dsd.io.tf
+++ b/terraform/dsd.io.tf
@@ -1647,15 +1647,6 @@ module "dsd_io_records" {
       ]
     },
     {
-      name = "one3one.dsd.io.",
-      type = "A",
-      alias = {
-        zone_id                = "Z1BKCTXD74EZPE"
-        name                   = "s3-website-eu-west-1.amazonaws.com."
-        evaluate_target_health = false
-      }
-    },
-    {
       name = "openjustice.dsd.io.",
       type = "CNAME",
       ttl  = 300,


### PR DESCRIPTION
This PR changes `dsd.io` subdomain records to use aliases for S3 buckets rather than CNAME records, resulting in improved performance and a reduced cost.

It also removes the record for `one3one.dsd.io`, pointing to `one3one.dsd.io.s3-website-eu-west-1.amazonaws.com`, as the specified bucket does not exist.