### PR TITLE
Tag hosted zones for Youth Justice Board domains

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -31,4 +31,16 @@ locals {
     source-code            = "github.com/ministryofjustice/dns-iac"
     terraform              = true
   }
+  default_hosted_zone_tags = {
+    is-production = false
+    source-code   = "github.com/ministryofjustice/dns-iac"
+    terraform     = true
+  }
+}
+
+locals {
+  yjb_tags = merge(locals.default_hosted_zone_tags, {
+    business-unit = "YJB"
+    owner         = "Youth Justice Board ICT: ict@yjb.gov.uk"
+  })
 }

--- a/terraform/yjb.gov.uk.tf
+++ b/terraform/yjb.gov.uk.tf
@@ -2,9 +2,10 @@ module "yjb_gov_uk_zone" {
   source = "./modules/route53/zone"
 
   name = "yjb.gov.uk"
-  tags = {
-    component = "None"
-  }
+  tags = merge(local.yjb_tags, {
+    is-production = true
+    application   = "Youth Justice Board root domain"
+  })
 }
 
 module "yjb_gov_uk_records" {

--- a/terraform/yjbpublications.justice.gov.uk.tf
+++ b/terraform/yjbpublications.justice.gov.uk.tf
@@ -2,10 +2,10 @@ module "yjbpublications_justice_gov_uk_zone" {
   source = "./modules/route53/zone"
 
   name = "yjbpublications.justice.gov.uk"
-
-  tags = {
-    component = "None"
-  }
+  tags = merge(local.yjb_tags, {
+    is-production = true
+    application   = "Youth Justice Board Publications: Redirect to GOV.UK"
+  })
 }
 
 module "yjbpublications_justice_gov_uk_records" {

--- a/terraform/yjils.justice.gov.uk.tf
+++ b/terraform/yjils.justice.gov.uk.tf
@@ -2,9 +2,10 @@ module "yjils_justice_gov_uk_zone" {
   source = "./modules/route53/zone"
 
   name = "yjils.justice.gov.uk"
-  tags = {
-    component = "None"
-  }
+  tags = merge(local.yjb_tags, {
+    is-production = true
+    application   = "Youth Justice Interactive Learning Space"
+  })
 }
 
 module "yjils_justice_gov_uk_records" {


### PR DESCRIPTION
This PR tags the following hosted zones with contact details for each domain:

- `yjb.gov.uk`
- `yjbpublications.justice.gov.uk`
- `yjils.justice.gov.uk`