### PR TITLE
Add DNS TXT Record for laa-crime.service.justice.gov.uk

### DIFF
--- a/terraform/service.justice.gov.uk.tf
+++ b/terraform/service.justice.gov.uk.tf
@@ -245,6 +245,14 @@ module "service_justice_gov_uk_records" {
       ]
     },
     {
+      name = "laa-crime.service.justice.gov.uk"
+      type = "TXT"
+      ttl  = 300
+      records = [
+        "OSSRH-90962"
+      ]
+    },
+    {
       name = "bichard7.service.justice.gov.uk."
       type = "NS"
       ttl  = 300


### PR DESCRIPTION
New DNS TXT record for the `laa-crime.service.justice.gov.uk` subdomain.

This will enable us to prove ownership of the domain so that we can publish packages under the relevant group id to maven central.

https://issues.sonatype.org/browse/OSSRH-90962